### PR TITLE
Fix bug on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,15 @@ target_compile_options(elf2vkp
 		$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
 )
 
-# target_link_options(elf2vkp PUBLIC -static)
+# EXL, 02-Jan-2025: Enable static linking and executable stripping for MinGW.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_SYSTEM_NAME MATCHES "Windows")
+	target_link_options(elf2vkp PUBLIC
+		"-s"
+		"-static"
+		"-static-libgcc"
+		"-static-libstdc++"
+		"-Wl,--gc-sections"
+	)
+endif()
+
 install(TARGETS elf2vkp DESTINATION /usr/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,22 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(elf2vkp)
+project(elf2vkp LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 include_directories("./third_party/argparse/include" "./third_party")
 
 add_executable(elf2vkp src/main.cpp)
+
 target_precompile_headers(elf2vkp PRIVATE <argparse/argparse.hpp> <string> <vector>)
+
+# EXL, 02-Jan-2025: Enable high levels of compiler warnings.
+target_compile_options(elf2vkp
+	PUBLIC -O3
+	PRIVATE
+		$<$<CXX_COMPILER_ID:MSVC>:/W3>
+		$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>
+)
+
 # target_link_options(elf2vkp PUBLIC -static)
-target_compile_options(elf2vkp PUBLIC -O3)
 install(TARGETS elf2vkp DESTINATION /usr/bin)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The main reason for the existence of this program is that the sources of the old
 	cd build
 	cmake ..
 	make -j$(nproc)
+	
+	# Windows (MinGW)
+	mkdir build
+	cd build
+	cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-x86_64-w64-mingw32.cmake
+	make -j$(nproc)
 	```
 
 # USAGE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,12 +134,12 @@ std::string generatePatch(const Config &config, const std::vector<PatchData> &ch
 				strprintf("0x%08X: ", c.addr + i - config.base) :
 				strprintf("%07X: ", c.addr + i - config.base);
 			if (c.oldData.size() > 0 && !oldDataEqualFF) {
-				for (int j = i; j < std::min(i + config.chunkSize, c.size); j++) {
+				for (uint32_t j = i; j < std::min(i + config.chunkSize, c.size); j++) {
 					patchFile += strprintf("%02X", c.oldData[j]);
 				}
 				patchFile += " ";
 			}
-			for (int j = i; j < std::min(i + config.chunkSize, c.size); j++) {
+			for (uint32_t j = i; j < std::min(i + config.chunkSize, c.size); j++) {
 				patchFile += strprintf("%02X", c.newData[j]);
 			}
 			patchFile += eol;
@@ -282,7 +282,6 @@ std::vector<uint8_t> readBinaryFile(const std::string &path) {
 	std::vector<uint8_t> bytes;
 	bytes.resize(maxFileSize);
 
-	char buff[4096];
 	size_t readed = 0;
 	while (!feof(fp) && readed < maxFileSize) {
 		int ret = fread(&bytes[readed], 1, std::min(static_cast<size_t>(4096), maxFileSize - readed), fp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,7 +273,7 @@ std::string readFile(const std::string &path) {
 }
 
 std::vector<uint8_t> readBinaryFile(const std::string &path) {
-	FILE *fp = fopen(path.c_str(), "r");
+	FILE *fp = fopen(path.c_str(), "rb");
 	if (!fp) {
 		throw std::runtime_error("fopen(" + path + ") error: " + strerror(errno));
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ std::vector<PatchData> getPatchDataFromELF(const Config &config, const std::stri
 	FILE *fullflashFp = nullptr;
 
 	if (fullflashFile != "") {
-		fullflashFp = fopen(fullflashFile.c_str(), "r");
+		fullflashFp = fopen(fullflashFile.c_str(), "rb");
 		if (!fullflashFp)
 			throw std::runtime_error(strprintf("Can't open fullflash file: %s", fullflashFile.c_str()));
 	}
@@ -255,7 +255,7 @@ std::vector<Elf32_Shdr *> getSectionsFromSegment(std::vector<uint8_t> &buffer, E
 }
 
 std::string readFile(const std::string &path) {
-	FILE *fp = fopen(path.c_str(), "r");
+	FILE *fp = fopen(path.c_str(), "rb");
 	if (!fp) {
 		throw std::runtime_error("fopen(" + path + ") error: " + strerror(errno));
 	}

--- a/src/main.h
+++ b/src/main.h
@@ -4,6 +4,12 @@
 #include <cstdint>
 #include <qemu/elf.h>
 
+#if defined(_WIN32) || defined(__MINGW32__)
+	#define SIZET_FMT "%Iu"
+#else
+	#define SIZET_FMT "%zu"
+#endif
+
 struct Config {
 	uint32_t base;
 	bool oldPrintFormat;
@@ -35,6 +41,6 @@ std::string generatePatch(const Config &baseOffset, const std::vector<PatchData>
 template<typename T>
 T *getSafePtr(std::vector<uint8_t> &buffer, size_t offset) {
 	if (offset + sizeof(T) > buffer.size())
-		throw std::runtime_error(strprintf("Unexpected ELF file EOF at %d", offset + sizeof(T)));
+		throw std::runtime_error(strprintf("Unexpected ELF file EOF at " SIZET_FMT, offset + sizeof(T)));
 	return reinterpret_cast<T *>(&buffer[offset]);
 }


### PR DESCRIPTION
`fopen(path.c_str(), "r")` vs `fopen(path.c_str(), "rb")` variants have different behavior on UNIX-like and Windows